### PR TITLE
Fix typo in FAQ page

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -40,7 +40,7 @@ Provisioner fails at task **[Wait for all nodes to have SSH reachability]**
 
 Make sure there is a private key of the form <<workshop_name>>-private.pem in folder f5_provisioner/provisioner/<<workshop_name>>/
 
-If ley is not present run the following: 
+If the private key is not present, run the following: 
 
 - Teardown lab: ansible-playbook teardown_lab.yml -e @f5_vars.yml 
 - Provision again: ansible-playbook provision_lab.yml -e @f5_vars.yml 


### PR DESCRIPTION
changed line 43 from
if the ley is not present run the following: 
to 
If the private key is not present, run the following: